### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,76 @@
-# builder
-FROM gcc:12.4-bookworm as builder
-WORKDIR /usr/src/coconut
-COPY . .
-# curl and gcc
-RUN apt-get update && apt-get install -y libcurl-dev && rm -rf /var/lib/apt/lists/*
-RUN gcc -o coconut coconut.c -lcurl
+# ---------------------------------
+# Builder
+# ---------------------------------
+FROM continuumio/miniconda3:25.3.1-1 AS builder
 
+LABEL org.opencontainers.image.title="Coconut Builder Image" \
+      org.opencontainers.image.description="Builder stage for Coconut application with Conda environment" \
+      org.opencontainers.image.authors="Juan Mac Donagh (SBG-UNQ), Gustavo Parisi (SBG-UNQ)" \
+      org.opencontainers.image.source="https://github.com/Juanmacdonagh17/coconut_repo" \
+      org.opencontainers.image.vendor="SBG-UNQ" \
+      org.opencontainers.image.version="1.0.0" \
+      org.opencontainers.image.created="2025-06-10" \
+      maintainer.email="macjuan17@gmail.com" \
+      stage.purpose="Build environment for Coconut application" \
+      build.dependencies="miniconda3,gcc,libcurl" \
+      build.target="coconut executable"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN conda install -c conda-forge -y \
+        libcurl \
+        curl \
+        gcc_linux-64 \
+        gxx_linux-64 && \
+    conda clean -afy
+
+ENV SCRIPT_DIR="/usr/src/coconut" \
+    COCONUT_SOURCE="/usr/src/coconut/coconut.c" \
+    CONDA_GCC="/opt/conda/bin/x86_64-conda-linux-gnu-gcc" \
+    CONDA_PREFIX="/opt/conda"
+
+WORKDIR $SCRIPT_DIR
+COPY *.c *.h ./
+
+RUN conda run $CONDA_GCC -o coconut "$COCONUT_SOURCE" \
+    -I"$CONDA_PREFIX/include" \
+    -L"$CONDA_PREFIX/lib" \
+    -Wl,-rpath,"$CONDA_PREFIX/lib" \
+    -lcurl \
+    -lm
+
+# ---------------------------------
 # Runner
-FROM debian:11-slim as runner
+# ---------------------------------
+FROM debian:bookworm AS runner
 
-# add a user so that whoever uses this image doesn't have root privileges without knowing it
-RUN useradd -ms /bin/bash cocouser
+LABEL org.opencontainers.image.title="Coconut" \
+      org.opencontainers.image.description="A suite for transcripts, codon usage and protein structure analysis" \
+      org.opencontainers.image.url="https://github.com/Juanmacdonagh17/coconut_repo" \
+      org.opencontainers.image.documentation="https://github.com/Juanmacdonagh17/coconut_repo" \
+      org.opencontainers.image.authors="Juan Mac Donagh (SBG-UNQ), Gustavo Parisi (SBG-UNQ)" \
+      org.opencontainers.image.source="https://github.com/Juanmacdonagh17/coconut_repo" \
+      org.opencontainers.image.vendor="SBG-UNQ" \
+      org.opencontainers.image.version="1.0.0" \
+      org.opencontainers.image.created="2025-06-10" \
+      maintainer.email="macjuan17@gmail.com" \
+      stage.purpose="Production runtime for Coconut application" \
+      runtime.dependencies="libcurl4" \
+      security.features="non-root-user" \
+      base.image="debian:bookworm"
 
-# switch to the user's home directory (cocouser)
+# Create non-root user and install dependencies in a single layer
+RUN useradd -ms /bin/bash -u 10001 cocouser && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libcurl4 \
+        ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /home/cocouser
 
-# install required runtime libraries
-RUN apt-get update && apt-get install -y libcurl4 && rm -rf /var/lib/apt/lists/*
+# Copy only the necessary files
+COPY --from=builder --chown=cocouser:cocouser /usr/src/coconut/coconut /home/cocouser/coconut
 
-# copy the executable from the builder
-COPY --from=builder /usr/src/coconut/coconut /home/cocouser/coconut
-
-# change ownership to cocouser
-RUN chown -R cocouser:cocouser /home/cocouser
-
-USER cocouser
-
-ENTRYPOINT ["/home/cocouser/coconut"]
+# Switch to non-root user
+USER cocouser:cocouser


### PR DESCRIPTION
## Abstract
Another approach to build a Docker image that compiles the coconut c-lang code into a binary using gcc (and other libraries) within a miniconda environment. 

## Details

There are two stages:

1. **Builder:** Starts from `continuumio/miniconda3:25.3.1-1` image containing miniconda installed inside the image. 
2. **Runner:** Copies the binary files to a Debian 12 (Bookworm) image (`debian:bookworm`). 

### Usage

```bash
DOCKER_DEFAULT_PLATFORM=linux/amd64 docker run --rm bio2byte/sbg-unq-coconut:8424d90 /home/cocouser/coconut -help
```

## Links

I have pushed a version of this image inside the Bio2Byte organisation on Docker Hub aiming to provide an online image to the pipeline I'm building for the IDPfun2 collaboration project (https://github.com/Bio2Byte/idpfun2-codon-bias-nf). However, that images uses a `debian:bookworm-slim` image for the runner causing an error when running it from Nextflow with the flag `-with-report`. That's why here I'm using a regular Debian.

- View image [bio2byte/sbg-unq-coconut:
8424d90](https://hub.docker.com/repository/docker/bio2byte/sbg-unq-coconut)
